### PR TITLE
Not okuma arayüz yükseklik sınırı

### DIFF
--- a/not-oku.php
+++ b/not-oku.php
@@ -35,7 +35,7 @@
                 <div class="card-header p-3 mt-2">
                     <h2 class="text-center mb-3"><?php echo veriCoz($baslik); ?></h2>
                 </div>
-                <div class="card-body" style="height:300px;">
+                <div class="card-body">
                     <p class="text-muted"><?php echo nl2br(veriCoz($detay)); ?></p>
                 </div>
                 <div class="card-footer">


### PR DESCRIPTION
Not okuma arayüzünde not okurken notun bir kısmı css yükseklik sınırlaması nedeniyle gözükmüyordu, o sınrlama kaldırıldı.